### PR TITLE
Fix demon asset and play again bug

### DIFF
--- a/assets/demon.svg
+++ b/assets/demon.svg
@@ -1,0 +1,40 @@
+<svg viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Demon">
+  <defs>
+    <linearGradient id="g-head" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#8b0a0a" />
+      <stop offset="100%" stop-color="#3b0a0a" />
+    </linearGradient>
+    <linearGradient id="g-body" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#a31616" />
+      <stop offset="100%" stop-color="#4a0e0e" />
+    </linearGradient>
+    <radialGradient id="g-eye" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#fff3" />
+      <stop offset="60%" stop-color="#ff3b3b" />
+      <stop offset="100%" stop-color="#7a0d0d" />
+    </radialGradient>
+    <filter id="shadow" x="-50%" y="-50%" width="200%" height="200%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#000" flood-opacity="0.5" />
+    </filter>
+  </defs>
+
+  <g filter="url(#shadow)">
+    <path d="M40 48 L86 8 L96 68 Z" fill="#2b0000"/>
+    <path d="M216 48 L170 8 L160 68 Z" fill="#2b0000"/>
+
+    <ellipse cx="128" cy="112" rx="94" ry="76" fill="url(#g-head)" stroke="#1a0000" stroke-width="3"/>
+
+    <path d="M48 150 Q128 190 208 150 Q188 220 128 228 Q68 220 48 150 Z" fill="url(#g-body)" stroke="#1a0000" stroke-width="3"/>
+
+    <ellipse cx="98" cy="110" rx="18" ry="16" fill="url(#g-eye)"/>
+    <ellipse cx="158" cy="110" rx="18" ry="16" fill="url(#g-eye)"/>
+    <circle cx="100" cy="110" r="5" fill="#000"/>
+    <circle cx="156" cy="110" r="5" fill="#000"/>
+
+    <path d="M88 140 Q128 162 168 140" fill="none" stroke="#000" stroke-width="6" stroke-linecap="round"/>
+
+    <g opacity="0.35">
+      <circle cx="128" cy="200" r="40" fill="#000"/>
+    </g>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -13,29 +13,7 @@
         <div id="enemy-area">
           <div id="enemy">
             <div id="demon-sprite" aria-label="Demon" role="img">
-              <!-- Simple inline demon SVG -->
-              <svg viewBox="0 0 200 160" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                <defs>
-                  <linearGradient id="demonGrad" x1="0" x2="1" y1="0" y2="1">
-                    <stop offset="0%" stop-color="#3a0d0d" />
-                    <stop offset="100%" stop-color="#5a0f0f" />
-                  </linearGradient>
-                </defs>
-                <!-- Horns -->
-                <path d="M45 30 L65 5 L75 40 Z" fill="#2a0202" />
-                <path d="M155 30 L135 5 L125 40 Z" fill="#2a0202" />
-                <!-- Head -->
-                <ellipse cx="100" cy="70" rx="70" ry="55" fill="url(#demonGrad)" stroke="#000" stroke-width="2" />
-                <!-- Eyes -->
-                <ellipse cx="75" cy="65" rx="12" ry="10" fill="#ff3b3b" />
-                <ellipse cx="125" cy="65" rx="12" ry="10" fill="#ff3b3b" />
-                <circle cx="76" cy="65" r="4" fill="#000" />
-                <circle cx="124" cy="65" r="4" fill="#000" />
-                <!-- Mouth -->
-                <path d="M70 95 Q100 115 130 95" fill="none" stroke="#000" stroke-width="4" stroke-linecap="round" />
-                <!-- Body shadow -->
-                <ellipse cx="100" cy="140" rx="45" ry="8" fill="#000" opacity="0.25" />
-              </svg>
+              <img src="assets/demon.svg" alt="Demon" />
             </div>
             <div id="enemy-type-badge" title="Enemy type"><span id="enemy-type-emoji">🔥</span></div>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,8 @@
 
 * { box-sizing: border-box; }
 
+[hidden] { display: none !important; }
+
 html, body {
   height: 100%;
 }
@@ -67,7 +69,7 @@ body {
   height: 96px;
 }
 
-#demon-sprite svg {
+#demon-sprite img {
   width: 100%;
   height: 100%;
   display: block;


### PR DESCRIPTION
Replace inline demon SVG with an external asset and fix the game starting with the "Play Again" overlay.

---
<a href="https://cursor.com/background-agent?bcId=bc-10e8cdfd-8fb4-4d75-8d5c-7afe3a531eb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10e8cdfd-8fb4-4d75-8d5c-7afe3a531eb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

