### PR TITLE
Enhance health bar visuals

### DIFF
--- a/game.js
+++ b/game.js
@@ -217,6 +217,9 @@
     const pPct = Math.round((playerHP / PLAYER_MAX_HP) * 100);
     enemyFill.style.width = `${ePct}%`;
     playerFill.style.width = `${pPct}%`;
+    playerFill.style.background = healthGradient(pPct);
+    enemyPts.style.color = ePct < 30 ? getCssVar("--danger") : getCssVar("--muted");
+    playerPts.style.color = pPct < 30 ? getCssVar("--danger") : getCssVar("--muted");
     enemyPts.textContent = `${enemyHP} / ${ENEMY_MAX_HP}`;
     playerPts.textContent = `${playerHP} / ${PLAYER_MAX_HP}`;
   }
@@ -281,6 +284,11 @@
   function clamp(v, min, max) { return Math.max(min, Math.min(max, v)); }
   function clearChildren(node) { while (node.firstChild) node.removeChild(node.firstChild); }
   function getCssVar(name) { return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || "#fff"; }
+
+  function healthGradient(pct) {
+    const hue = (pct / 100) * 120;
+    return `linear-gradient(90deg, hsl(${hue}, 70%, 50%), hsl(${hue}, 70%, 65%))`;
+  }
 
   function showToast(message) {
     toast.textContent = message;

--- a/styles.css
+++ b/styles.css
@@ -106,6 +106,7 @@ body {
   height: 100%;
   width: 100%;
   background: linear-gradient(90deg, #6ee7b7, #10b981);
+  transition: width 300ms ease;
 }
 
 .health-points {


### PR DESCRIPTION
## Summary
- Animate health bar changes for smoother feedback
- Color player health bar based on remaining life and highlight low health values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689db2b315b4832984a76ed33c04ccd3